### PR TITLE
CORS in go lambda and API gateway via OPTIONS request

### DIFF
--- a/functions/hello/main.go
+++ b/functions/hello/main.go
@@ -259,9 +259,13 @@ func (app *App) Handler(ctx context.Context, req *events.APIGatewayProxyRequest)
 		return errorResponse(http.StatusInternalServerError, "problem with query", err), nil
 	}
 
+	// headers
+	headers := map[string]string{"Access-Control-Allow-Origin": "*"}
+
 	response := &events.APIGatewayProxyResponse{
 		StatusCode: http.StatusOK,
 		Body:       body,
+		Headers:		headers,
 	}
 
 	return response, nil

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -227,6 +227,15 @@ resource "aws_api_gateway_method" "fi-get-hello" {
   authorization = "NONE"
 }
 
+# configure CORS on /hello/{dataset}
+module "cors" {
+  source = "squidfunk/api-gateway-enable-cors/aws"
+  version = "0.3.3"
+
+  api_id          = aws_api_gateway_rest_api.fi-hello.id
+  api_resource_id = aws_api_gateway_resource.fi-hello-dataset.id
+}
+
 # Integrate GET /hello/{dataset} method with lambda
 #
 resource "aws_api_gateway_integration" "fi-get-hello" {


### PR DESCRIPTION
- add CORS header to lambda response event
- add OPTIONS endpoint with CORS response for preflight checks
in API gateway config

These changes needed to allow browser code to use the API