### PR TITLE
tag integration tests to allow selective running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ debug:	## run poc service in debug mode
 test:	## run poc tests
 	go test -race -cover ./...
 
+.PHONY: test-integration
+test-integration:	## run poc tests AND integration tests in inttests
+	go test -race -cover ./... -tags=integration
+
 .PHONY: convey
 convey:	## run goconvey
 	goconvey ./...

--- a/inttests/Makefile
+++ b/inttests/Makefile
@@ -5,26 +5,26 @@ all:
 
 # Update stored responses under 'resp' directory
 .PHONY: update
-update:	
+update:
 	@go run .
 
 # Usual test
 .PHONY: test
-test:	
-	@go test ./...
+test:
+	@go test ./... -tags=integration
 
 # Verbose test
 .PHONY: testv
 testv:
-	 @go test -v ./...
+	 @go test -v ./... -tags=integration
 
 # Very verbose test - displays long coloured diffs for failures
 .PHONY: testvv
 testvv:
-	 @go test -v ./... -args extra
+	 @go test -v ./... -args extra -tags=integration
 
 
 # Benchmark
 .PHONY: bench
 bench:
-	 @go test -bench .
+	 @go test -bench . -tags=integration

--- a/inttests/main.go
+++ b/inttests/main.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (

--- a/inttests/main_test.go
+++ b/inttests/main_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (


### PR DESCRIPTION
### What

Add 'integration' build tag to go files in /inttests so that
'go test' will not run integration tests. Instead you need to
'go test -tags=integration'.

This change needed to allow selective running of integration tests
when appropriate.

Make rules for running tests in /inttests changed as appropriate,
and specific 'test-integration' rule added to Makefile in root.

### How to review

- run `make test` from project root and check that tests from `/inttests` do NOT run
- run `make test-integration` from project root and check that tests from `/inttests` DO run

### Who can review

Anyone