### PR TITLE
assert CORS='*' header in integration test API responses

### DIFF
--- a/inttests/Makefile
+++ b/inttests/Makefile
@@ -21,7 +21,7 @@ testv:
 # Very verbose test - displays long coloured diffs for failures
 .PHONY: testvv
 testvv:
-	 @go test -v ./... -args extra -tags=integration
+	 @go test -v ./... -tags=integration -args extra
 
 
 # Benchmark

--- a/inttests/main.go
+++ b/inttests/main.go
@@ -13,10 +13,12 @@ import (
 	"strings"
 )
 
-var Tests = []struct {
+type APITest = struct {
 	desc     string
 	url      string
-}{
+}
+
+var Tests = []APITest{
 	{
 		"no params",
 		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/atlas2011.qs119ew`,

--- a/inttests/main.go
+++ b/inttests/main.go
@@ -96,7 +96,7 @@ var DataPref = "resp/"
 func main() {
 	// populate saved copies to allow test diffs
 	for _, test := range Tests {
-		b, err := HTTPget(test.url)
+		b, _, err := HTTPget(test.url)
 
 		if err != nil {
 			log.Print(err)
@@ -115,28 +115,30 @@ func main() {
 	}
 }
 
-func HTTPget(s string) (b []byte, err error) {
+func HTTPget(s string) (b []byte, h map[string][]string, err error) {
 	resp, err := http.Get(s)
 
 	if err != nil {
-		return b, err
+		return b, h, err
 	}
 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		err := errors.New(fmt.Sprintf("API responded with status code %v", resp.StatusCode))
-		return b, err
+		return b, h, err
 	}
 
 	// or just io. in go 1.16+
 	b, err = ioutil.ReadAll(resp.Body)
 
 	if err != nil {
-		return b, err
+		return b, h, err
 	}
 
-	return b, err
+	h = resp.Header
+
+	return b, h, err
 }
 
 func sha1Hash(b []byte) string {
@@ -172,4 +174,13 @@ func MatchingRespFile(testDesc string) (fns []string, err error) {
 		}
 	}
 	return fns, err
+}
+
+func IsStringInSlice(str string, s []string) (bool) {
+	for _, ele := range(s) {
+		if ele == str {
+			return true
+		}
+	}
+	return false
 }

--- a/inttests/main_test.go
+++ b/inttests/main_test.go
@@ -17,11 +17,19 @@ func TestAPI(t *testing.T) {
 
 		t.Run(test.desc, func(t *testing.T) {
 
-			b, err := HTTPget(test.url)
+			b, header, err := HTTPget(test.url)
 
 			if err != nil {
 				t.Errorf("Error getting %s: %v", test.url, err)
 			} else {
+				cors, ok := header["Access-Control-Allow-Origin"]
+				if ok {
+					if !IsStringInSlice("*", cors) {
+						t.Errorf("Expected '*' to be included in CORS header value for response from %s, got %v", test.url, cors)
+					}
+				} else {
+					t.Errorf("CORS header missing in response from %s", test.url)
+				}
 				wantfiles, err := MatchingRespFile(test.desc)
 				if err != nil {
 					t.Fail()
@@ -66,7 +74,7 @@ func TestAPI(t *testing.T) {
 func BenchmarkAllTestAPI(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, test := range Tests {
-			_, err := HTTPget(test.url)
+			_, _, err := HTTPget(test.url)
 			if err != nil {
 				panic(err)
 			}

--- a/inttests/main_test.go
+++ b/inttests/main_test.go
@@ -21,53 +21,69 @@ func TestAPI(t *testing.T) {
 
 			if err != nil {
 				t.Errorf("Error getting %s: %v", test.url, err)
-			} else {
-				cors, ok := header["Access-Control-Allow-Origin"]
-				if ok {
-					if !IsStringInSlice("*", cors) {
-						t.Errorf("Expected '*' to be included in CORS header value for response from %s, got %v", test.url, cors)
-					}
 				} else {
-					t.Errorf("CORS header missing in response from %s", test.url)
-				}
-				wantfiles, err := MatchingRespFile(test.desc)
-				if err != nil {
-					t.Fail()
-				}
-				switch len(wantfiles) {
-				case 0:
-					t.Errorf("No response file found for test '%s', looks like you need to re-run main.go!", test.desc)
-				case 1:
-					wantfile := wantfiles[0]
-					wantsha1 := RespFileSha1(wantfile)
-					h := sha1Hash(b)
-					if h != wantsha1 {
-						t.Errorf("wrongly got: %s", h)
-
-						// use 'go test ./... -args extra'
-						// for diff
-
-						if os.Args[len(os.Args)-1] == "extra" {
-
-							dmp := diffmatchpatch.New()
-
-							f, _ := os.Open(DataPref + wantsha1)
-
-							wanted, _ := io.ReadAll(f)
-
-							diffs := dmp.DiffMain(string(b), string(wanted), true)
-
-							t.Log(dmp.DiffPrettyText(diffs))
-						}
-					}
-				default:
-					t.Errorf(
-						"Multiple response files found for test '%s', try manually auditing files and re-run main.go",
-						test.desc,
-					)
-				}
+					assertCORSHeader(header, test, t)
+					assertAPIResponse(b, test, t)
 			}
 		})
+	}
+}
+
+// Assert CORS header allows cross-origin requests from any source (needed for web apps to use the API)
+func assertCORSHeader(h map[string][]string, test APITest, t *testing.T) {
+	cors, ok := h["Access-Control-Allow-Origin"]
+	if ok {
+		if !IsStringInSlice("*", cors) {
+			t.Errorf("Expected '*' to be included in CORS header value for response from %s, got '%s'", test.url, cors)
+		}
+	} else {
+		t.Errorf("CORS header missing in response from %s", test.url)
+	}
+}
+
+// Assert API responses are consistent with recorded ones
+func assertAPIResponse(b []byte, test APITest, t*testing.T) {
+	respfiles, err := MatchingRespFile(test.desc)
+	if err != nil {
+		t.Fail()
+	}
+	switch len(respfiles) {
+	case 0:
+		// if no recorded response is available, main.go needs to be run to capture it
+		t.Errorf("No response file found for test '%s', looks like you need to re-run main.go!", test.desc)
+
+	case 1:
+		// check API response against the one on file
+		respfile := respfiles[0]
+		wantsha1 := RespFileSha1(respfile)
+		h := sha1Hash(b)
+		if h != wantsha1 {
+			t.Errorf("Response from %s differed from that recorded in file %s. Run 'make testvv' to see full diff.", test.url, respfile)
+
+			// use 'go test ./... -args extra'
+			// for diff
+
+			if os.Args[len(os.Args)-1] == "extra" {
+
+				dmp := diffmatchpatch.New()
+
+				f, _ := os.Open(DataPref + wantsha1)
+
+				wanted, _ := io.ReadAll(f)
+
+				diffs := dmp.DiffMain(string(b), string(wanted), true)
+
+				t.Log(dmp.DiffPrettyText(diffs))
+			}
+		}
+
+	default:
+		// if multiple recorded responses are found, a manual check is needed - possible cause is main.go was ran, and
+		// the response for a previously-recorded API query differed from previous, and so was saved as a new response file.
+		t.Errorf(
+			"Multiple response files found for test '%s', try manually auditing files and re-run main.go",
+			test.desc,
+		)
 	}
 }
 


### PR DESCRIPTION
### What

commit ae036b0315ad2cec7d44ed9b4ac284b64e3dee4f (HEAD -> feature/integration-test-CORS-headers, origin/feature/integration-test-CORS-headers)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Fri Nov 19 08:55:56 2021 +0000

    extract inttests/main_test.TestAPI regression test to seperate func

    Move tests for regression in API responses from inside TestAPI
    test to seperate function in inttests/main_test.go. This change
    intended to improve readability.

    Misc:
    - fix bug where 'make testvv' rule was not working due to
    wrong order of arguments.

commit 0f9dc653f2718051da7b9f40de60bb3bd66a55c9
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Tue Nov 16 15:57:50 2021 +0000

    assert CORS='*' header in integration test API responses

    Add clause to TestAPI in /inttest/main_test.go that checks
    headers of API responses for
    'Access-Control-Allow-Origin': '*'

    This change needed to test API can be used by browser code.

### How to review

eyeball code.

### Who can review

Anyone