### PR TITLE
change metric from string to float64

### DIFF
--- a/pkg/demo/demo.go
+++ b/pkg/demo/demo.go
@@ -119,7 +119,7 @@ AND geo_metric.category_id = nomis_category.id
 
 		var geo string
 		var cat string
-		var value string
+		var value float64
 
 		tscan.Start()
 		err := rows.Scan(&geo, &cat, &value)

--- a/pkg/table/table_test.go
+++ b/pkg/table/table_test.go
@@ -18,7 +18,7 @@ func TestGenerate(t *testing.T) {
 	type row struct {
 		geo string
 		cat string
-		val string
+		val float64
 	}
 
 	var tests = []struct {
@@ -34,37 +34,67 @@ func TestGenerate(t *testing.T) {
 		{
 			desc: "single category",
 			input: []row{
-				{"geo", "cat", "val"},
+				{"geo", "cat", 1.23},
 			},
-			want: "geography_code,cat\ngeo,val\n",
+			want: "geography_code,cat\ngeo,1.23\n",
 		},
 		{
 			desc: "multiple categories",
 			input: []row{
-				{"geo", "cat2", "val2"},
-				{"geo", "cat1", "val1"},
+				{"geo", "cat2", 0},
+				{"geo", "cat1", 45.6},
 			},
-			want: "geography_code,cat1,cat2\ngeo,val1,val2\n",
+			want: "geography_code,cat1,cat2\ngeo,45.6,0\n",
 		},
 		{
 			desc: "multiple geographies",
 			input: []row{
-				{"geo2", "cat", "val2"},
-				{"geo1", "cat", "val1"},
+				{"geo2", "cat", 7.8},
+				{"geo1", "cat", 9.101112},
 			},
-			want: "geography_code,cat\ngeo1,val1\ngeo2,val2\n",
+			want: "geography_code,cat\ngeo1,9.101112\ngeo2,7.8\n",
 		},
 		{
 			desc: "several geographies and categories",
 			input: []row{
-				{"sun", "mass", "1.98847e30"},
-				{"earth", "mass", "5.9722e24"},
-				{"moon", "mass", "7.348e22"},
-				{"sun", "diameter", "1392000"},
-				{"earth", "diameter", "12756"},
-				{"moon", "diameter", "3471"},
+				{"sun", "mass", 1.98847e+30},
+				{"earth", "mass", 5.9722e+24},
+				{"moon", "mass", 7.348e+22},
+				{"sun", "diameter", 1392000},
+				{"earth", "diameter", 12756},
+				{"moon", "diameter", 3471},
 			},
-			want: "geography_code,diameter,mass\nearth,12756,5.9722e24\nmoon,3471,7.348e22\nsun,1392000,1.98847e30\n",
+			want: "geography_code,diameter,mass\nearth,12756,5.9722e+24\nmoon,3471,7.348e+22\nsun,1392000,1.98847e+30\n",
+		},
+		// specific numeric formatting tests
+		{
+			desc: "zero should be printed with no decimals or spaces",
+			input: []row{
+				// zero should be printed as just "0", no decimals or spaces
+				{"here", "zero", 0},
+			},
+			want: "geography_code,zero\nhere,0\n",
+		},
+		{
+			desc: "large integers should be printed as integers, no decimals or spaces",
+			input: []row{
+				{"here", "millions", 123456789},
+			},
+			want: "geography_code,millions\nhere,123456789\n",
+		},
+		{
+			desc: "decimals should be printed without trailing zeros",
+			input: []row{
+				{"here", "decimal", 0.123000},
+			},
+			want: "geography_code,decimal\nhere,0.123\n",
+		},
+		{
+			desc: "12 digit decimals should be printed",
+			input: []row{
+				{"here", "12digits", 1.012345678901},
+			},
+			want: "geography_code,12digits\nhere,1.012345678901\n",
 		},
 	}
 


### PR DESCRIPTION
### What

Change the datatype of metric values from string to float64 so we have more control over formatting in the csv.