### PR TITLE
nightly run of integration tests in ./inttests

### DIFF
--- a/.github/workflows/nightly-integration-tests.yml
+++ b/.github/workflows/nightly-integration-tests.yml
@@ -1,5 +1,6 @@
 name: Nightly Integration Tests
 on:
+  workflow_dispatch: # manual trigger
   schedule:
     - cron: '20 4 * * *'
 jobs:

--- a/.github/workflows/nightly-integration-tests.yml
+++ b/.github/workflows/nightly-integration-tests.yml
@@ -1,0 +1,19 @@
+name: Nightly Integration Tests
+on:
+  schedule:
+    - cron: '20 4 * * *'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Develop Branch
+        uses: actions/checkout@develop
+
+      - name: Setup Go
+        uses: actions/setup-go@vs
+        with:
+          go-version: 1.17.3 # ToDo - can you use 'latest' here?
+
+      - name: Run Go Integration Tests
+        working-directory: ./inttests
+        run: make testvv


### PR DESCRIPTION
Add github action to run integration tests nightly.

### What

commit 0cab0618d9f7e0da36f07854c1bf07a847e03230 (HEAD -> featre/automated-integration-tests-github-actions, origin/featre/automated-integration-tests-github-actions)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Tue Nov 23 15:58:06 2021 +0000

    add manual trigger to nightly integration tests github action

commit 862a3cc651697471ec2041859474c6cf1c3fbf85 (HEAD -> featre/automated-integration-tests-github-actions, origin/featre/automated-integration-tests-github-actions)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Tue Nov 23 15:47:37 2021 +0000

    nightly run of integration tests in ./inttests

    Add github action to run integration tests nightly.

### How to review

look at the code - not sure it can be tested before merge?

### Who can review

anyone