### PR TITLE
allow all rows or cols in skinny queries, bump http write timeout

### DIFF
--- a/service/initialise.go
+++ b/service/initialise.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/ONSdigital/dp-find-insights-poc-api/config"
 	"github.com/ONSdigital/dp-find-insights-poc-api/pkg/aws"
@@ -56,6 +57,7 @@ func (e *ExternalServiceList) GetHealthCheck(cfg *config.Config, buildTime, gitC
 func (e *Init) DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer {
 	s := dphttp.NewServer(bindAddr, router)
 	s.HandleOSSignals = false
+	s.Server.WriteTimeout = 30 * time.Second
 	return s
 }
 


### PR DESCRIPTION
### What

Allow skinny queries to leave off rows= or cols= so 'all' is implied.
Also increased the http write timeout to 30s since some queries take >20s.