### PR TITLE
limit number of metrics processed per query

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -17,6 +17,7 @@ func main() {
 	dataset := flag.String("dataset", "", "name of dataset to query")
 	flag.Var(&rows, "rows", "row or row range")
 	flag.Var(&cols, "cols", "column name(s) to return")
+	maxmetrics := flag.Int("maxmetrics", 0, "max skinny rows to accept (default 0 means no limit)")
 	flag.Parse()
 
 	if *dataset == "" {
@@ -48,7 +49,7 @@ func main() {
 	}
 
 	// Set up our demo app
-	app, err := demo.New(db)
+	app, err := demo.New(db, *maxmetrics)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -63,6 +64,6 @@ func main() {
 }
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "usage: %s --dataset <dataset> --rows rowspec[,...] --cols col[,...]\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "usage: %s --dataset <dataset> [--rows rowspec[,...]] [--cols col[,...]] [--maxmetrics n]\n", os.Args[0])
 	os.Exit(2)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,8 @@ type Config struct {
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	EnableDatabase             bool          `envconfig:"ENABLE_DATABASE"`
+	MaxMetrics                 int           `envconfig:"MAX_METRICS"`
+	WriteTimeout               time.Duration `envconfig:"WRITE_TIMEOUT"`
 }
 
 var cfg *Config
@@ -29,6 +31,8 @@ func Get() (*Config, error) {
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
+		MaxMetrics:                 200000,           // max number of rows to accept from "geo" table queries
+		WriteTimeout:               30 * time.Second, // http WriteTimeout
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,6 +27,8 @@ func TestConfig(t *testing.T) {
 					HealthCheckInterval:        30 * time.Second,
 					HealthCheckCriticalTimeout: 90 * time.Second,
 					EnableDatabase:             false,
+					MaxMetrics:                 200000,
+					WriteTimeout:               30 * time.Second,
 				})
 			})
 

--- a/features/steps/example_component.go
+++ b/features/steps/example_component.go
@@ -2,10 +2,12 @@ package steps
 
 import (
 	"context"
+	"net/http"
+	"time"
+
 	"github.com/ONSdigital/dp-find-insights-poc-api/config"
 	"github.com/ONSdigital/dp-find-insights-poc-api/service"
 	"github.com/ONSdigital/dp-find-insights-poc-api/service/mock"
-	"net/http"
 
 	componenttest "github.com/ONSdigital/dp-component-test"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
@@ -81,8 +83,9 @@ func (c *Component) DoGetHealthcheckOk(cfg *config.Config, buildTime string, git
 	}, nil
 }
 
-func (c *Component) DoGetHTTPServer(bindAddr string, router http.Handler) service.HTTPServer {
+func (c *Component) DoGetHTTPServer(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer {
 	c.HTTPServer.Addr = bindAddr
 	c.HTTPServer.Handler = router
+	c.HTTPServer.WriteTimeout = writeTimeout
 	return c.HTTPServer
 }

--- a/functions/hello/main.go
+++ b/functions/hello/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -68,9 +69,23 @@ func NewApp() *App {
 		}
 	}
 
+	// Grab some config from the environment
+	//
+	var maxmetrics int = 200000
+	s := os.Getenv("MAX_METRICS")
+	if s != "" {
+		maxmetrics, err = strconv.Atoi(s)
+		if err != nil {
+			return &App{
+				errmsg: "bad MAX_METRICS value",
+				err:    err,
+			}
+		}
+	}
+
 	// Initialise our function's app
 	//
-	d, err := demo.New(db)
+	d, err := demo.New(db, maxmetrics)
 	if err != nil {
 		return &App{
 			errmsg: "cannot initialise demo app",

--- a/pkg/demo/errors.go
+++ b/pkg/demo/errors.go
@@ -1,0 +1,21 @@
+package demo
+
+type Sentinel string
+
+const (
+	ErrMissingParams  = Sentinel("rows or cols is missing")
+	ErrTooManyMetrics = Sentinel("too many metrics")
+	ErrInvalidTable   = Sentinel("invalid table")
+)
+
+func (e Sentinel) Error() string {
+	return string(e)
+}
+
+func (e Sentinel) Is(err error) bool {
+	sentinel, ok := err.(Sentinel)
+	if !ok {
+		return false
+	}
+	return sentinel == e
+}

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -30,8 +30,8 @@ func NewServiceList(initialiser Initialiser) *ExternalServiceList {
 type Init struct{}
 
 // GetHTTPServer creates an http server
-func (e *ExternalServiceList) GetHTTPServer(bindAddr string, router http.Handler) HTTPServer {
-	s := e.Init.DoGetHTTPServer(bindAddr, router)
+func (e *ExternalServiceList) GetHTTPServer(bindAddr string, router http.Handler, writeTimeout time.Duration) HTTPServer {
+	s := e.Init.DoGetHTTPServer(bindAddr, router, writeTimeout)
 	return s
 }
 
@@ -54,10 +54,10 @@ func (e *ExternalServiceList) GetHealthCheck(cfg *config.Config, buildTime, gitC
 }
 
 // DoGetHTTPServer creates an HTTP Server with the provided bind address and router
-func (e *Init) DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer {
+func (e *Init) DoGetHTTPServer(bindAddr string, router http.Handler, writeTimeout time.Duration) HTTPServer {
 	s := dphttp.NewServer(bindAddr, router)
 	s.HandleOSSignals = false
-	s.Server.WriteTimeout = 30 * time.Second
+	s.Server.WriteTimeout = writeTimeout
 	return s
 }
 

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/ONSdigital/dp-find-insights-poc-api/config"
 	"github.com/ONSdigital/dp-find-insights-poc-api/pkg/aws"
@@ -16,7 +17,7 @@ import (
 
 // Initialiser defines the methods to initialise external services
 type Initialiser interface {
-	DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer
+	DoGetHTTPServer(bindAddr string, router http.Handler, writeTimeout time.Duration) HTTPServer
 	DoGetHealthCheck(cfg *config.Config, buildTime, gitCommit, version string) (HealthChecker, error)
 	DoGetAWS() (*aws.Clients, error)
 	DoGetDatabase(driverName, dsn string) (*database.Database, error)

--- a/service/mock/initialiser.go
+++ b/service/mock/initialiser.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ONSdigital/dp-find-insights-poc-api/service"
 	"net/http"
 	"sync"
+	"time"
 )
 
 // Ensure, that InitialiserMock does implement service.Initialiser.
@@ -28,7 +29,7 @@ var _ service.Initialiser = &InitialiserMock{}
 // 			DoGetDatabaseFunc: func(driverName string, dsn string) (*database.Database, error) {
 // 				panic("mock out the DoGetDatabase method")
 // 			},
-// 			DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer {
+// 			DoGetHTTPServerFunc: func(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer {
 // 				panic("mock out the DoGetHTTPServer method")
 // 			},
 // 			DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
@@ -48,7 +49,7 @@ type InitialiserMock struct {
 	DoGetDatabaseFunc func(driverName string, dsn string) (*database.Database, error)
 
 	// DoGetHTTPServerFunc mocks the DoGetHTTPServer method.
-	DoGetHTTPServerFunc func(bindAddr string, router http.Handler) service.HTTPServer
+	DoGetHTTPServerFunc func(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer
 
 	// DoGetHealthCheckFunc mocks the DoGetHealthCheck method.
 	DoGetHealthCheckFunc func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error)
@@ -71,6 +72,8 @@ type InitialiserMock struct {
 			BindAddr string
 			// Router is the router argument value.
 			Router http.Handler
+			// WriteTimeout is the writeTimeout argument value.
+			WriteTimeout time.Duration
 		}
 		// DoGetHealthCheck holds details about calls to the DoGetHealthCheck method.
 		DoGetHealthCheck []struct {
@@ -152,33 +155,37 @@ func (mock *InitialiserMock) DoGetDatabaseCalls() []struct {
 }
 
 // DoGetHTTPServer calls DoGetHTTPServerFunc.
-func (mock *InitialiserMock) DoGetHTTPServer(bindAddr string, router http.Handler) service.HTTPServer {
+func (mock *InitialiserMock) DoGetHTTPServer(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer {
 	if mock.DoGetHTTPServerFunc == nil {
 		panic("InitialiserMock.DoGetHTTPServerFunc: method is nil but Initialiser.DoGetHTTPServer was just called")
 	}
 	callInfo := struct {
-		BindAddr string
-		Router   http.Handler
+		BindAddr     string
+		Router       http.Handler
+		WriteTimeout time.Duration
 	}{
-		BindAddr: bindAddr,
-		Router:   router,
+		BindAddr:     bindAddr,
+		Router:       router,
+		WriteTimeout: writeTimeout,
 	}
 	mock.lockDoGetHTTPServer.Lock()
 	mock.calls.DoGetHTTPServer = append(mock.calls.DoGetHTTPServer, callInfo)
 	mock.lockDoGetHTTPServer.Unlock()
-	return mock.DoGetHTTPServerFunc(bindAddr, router)
+	return mock.DoGetHTTPServerFunc(bindAddr, router, writeTimeout)
 }
 
 // DoGetHTTPServerCalls gets all the calls that were made to DoGetHTTPServer.
 // Check the length with:
 //     len(mockedInitialiser.DoGetHTTPServerCalls())
 func (mock *InitialiserMock) DoGetHTTPServerCalls() []struct {
-	BindAddr string
-	Router   http.Handler
+	BindAddr     string
+	Router       http.Handler
+	WriteTimeout time.Duration
 } {
 	var calls []struct {
-		BindAddr string
-		Router   http.Handler
+		BindAddr     string
+		Router       http.Handler
+		WriteTimeout time.Duration
 	}
 	mock.lockDoGetHTTPServer.RLock()
 	calls = mock.calls.DoGetHTTPServer

--- a/service/service.go
+++ b/service/service.go
@@ -63,7 +63,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 		}
 
 		// set up our query functionality if we have a db
-		queryDemo, err = demo.New(db)
+		queryDemo, err = demo.New(db, cfg.MaxMetrics)
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +90,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	rtr := chain.Then(api.Handler(a))
 
 	// bind router handler to http server
-	s := serviceList.GetHTTPServer(cfg.BindAddr, rtr)
+	s := serviceList.GetHTTPServer(cfg.BindAddr, rtr, cfg.WriteTimeout)
 
 	// Run the http server in a new go-routine
 	go func() {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -35,7 +35,7 @@ var funcDoGetHealthcheckErr = func(cfg *config.Config, buildTime string, gitComm
 	return nil, errHealthcheck
 }
 
-var funcDoGetHTTPServerNil = func(bindAddr string, router http.Handler) service.HTTPServer {
+var funcDoGetHTTPServerNil = func(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer {
 	return nil
 }
 
@@ -70,11 +70,11 @@ func TestRun(t *testing.T) {
 			return hcMock, nil
 		}
 
-		funcDoGetHTTPServer := func(bindAddr string, router http.Handler) service.HTTPServer {
+		funcDoGetHTTPServer := func(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer {
 			return serverMock
 		}
 
-		funcDoGetFailingHTTPSerer := func(bindAddr string, router http.Handler) service.HTTPServer {
+		funcDoGetFailingHTTPSerer := func(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer {
 			return failingServerMock
 		}
 
@@ -220,7 +220,9 @@ func TestClose(t *testing.T) {
 		Convey("Closing the service results in all the dependencies being closed in the expected order", func() {
 
 			initMock := &serviceMock.InitialiserMock{
-				DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer { return serverMock },
+				DoGetHTTPServerFunc: func(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer {
+					return serverMock
+				},
 				DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
 					return hcMock, nil
 				},
@@ -247,7 +249,9 @@ func TestClose(t *testing.T) {
 			}
 
 			initMock := &serviceMock.InitialiserMock{
-				DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer { return failingserverMock },
+				DoGetHTTPServerFunc: func(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer {
+					return failingserverMock
+				},
 				DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
 					return hcMock, nil
 				},


### PR DESCRIPTION
### What

Put a limit on the number of metrics a skinny query can return, just to prevent memory overruns now that rows and cols can be open ended.
This is done with a new MAX_METRICS environment variable used by the API and the lambda. Default is 200000.
The cli has --maxmetrics, and the default is 0, no limit.

Also make the API http write timeout configurable with the WRITE_TIMEOUT environment variable. Default is 30s.