### PR TITLE
remove CORS module for lambda datasets endpoint from main.tf

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -230,24 +230,6 @@ resource "aws_api_gateway_method" "fi-get-hello" {
   authorization = "NONE"
 }
 
-# configure CORS on /hello/{dataset}
-module "cors" {
-  source  = "squidfunk/api-gateway-enable-cors/aws"
-  version = "0.3.3"
-
-  api_id          = aws_api_gateway_rest_api.fi-hello.id
-  api_resource_id = aws_api_gateway_resource.fi-hello-dataset.id
-  allow_headers = [
-    "Authorization",
-    "Content-Type",
-    "Content-Encoding",
-    "X-Amz-Date",
-    "X-Amz-Security-Token",
-    "X-Api-Key"
-  ]
-}
-
-
 # Integrate GET /hello/{dataset} method with lambda
 #
 resource "aws_api_gateway_integration" "fi-get-hello" {


### PR DESCRIPTION
Remove call to third-party CORS module adding OPTIONS route to
lambdas dataset endpoint. This is not needed for GET or POST
requests, and so it not neccessary for the current API design.

### What

Describe what you have changed and why.

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
