### PR TITLE
get-readme-scaffold.sh makes readme scaffold from go doc output

### DIFF
--- a/get-readme-scaffold.sh
+++ b/get-readme-scaffold.sh
@@ -11,7 +11,7 @@ printf "\n## Project Contents\n" >> "$outfile"
 # loop through all non-hidden folders and try 'go doc --all' in them, write output to outfile if meaningful
 find . -type d -not -path '*/\.*' | while read -r dir
 do
-    printf "\n### dir: ${dir}\n" >> "$outfile"
+    printf "\n### [${dir}](${dir})\n" >> "$outfile"
     # print autodocs for any go code
     outContent=$(go doc -all "$dir" 2>/dev/null) && printf "\n*public Go code:*\n\`\`\` ${outContent} \n\`\`\`\n" >> "${outfile}"
     # link any readmes

--- a/get-readme-scaffold.sh
+++ b/get-readme-scaffold.sh
@@ -14,6 +14,6 @@ do
     # print autodocs for any go code
     outContent=$(go doc -all "$dir" 2>/dev/null) && printf "### public Go code:\n\`\`\` ${outContent} \n\`\`\`\n" >> "${outfile}"
     # link any readmes
-    cat "${dir}/README.md" &>/dev/null && printf "[LINK TO README](${dir}/README.md)\n" >> "${outfile}"
+    cat "${dir}/README.md" &>/dev/null && printf "See [README](${dir}/README.md) for more details.\n" >> "${outfile}"
 
 done

--- a/get-readme-scaffold.sh
+++ b/get-readme-scaffold.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+thisDir=$PWD
+outfile="${thisDir}/readme-scaffold.md"
+
+# prep outfile
+projName=$(basename "$thisDir")
+printf "# ${projName}\n" > "$outfile"
+
+# loop through all non-hidden folders and try 'go doc --all' in them, write output to outfile if meaningful
+find . -type d -not -path '*/\.*' | while read -r dir
+do
+    printf "\n## dir: ${dir}\n" >> "$outfile"
+    # print autodocs for any go code
+    outContent=$(go doc -all "$dir" 2>/dev/null) && printf "### public Go code:\n\`\`\` ${outContent} \n\`\`\`\n" >> "${outfile}"
+    # link any readmes
+    cat "${dir}/README.md" &>/dev/null && printf "[LINK TO README](${dir}/README.md)\n" >> "${outfile}"
+
+done

--- a/get-readme-scaffold.sh
+++ b/get-readme-scaffold.sh
@@ -6,13 +6,14 @@ outfile="${thisDir}/readme-scaffold.md"
 # prep outfile
 projName=$(basename "$thisDir")
 printf "# ${projName}\n" > "$outfile"
+printf "\n## Project Contents\n" >> "$outfile"
 
 # loop through all non-hidden folders and try 'go doc --all' in them, write output to outfile if meaningful
 find . -type d -not -path '*/\.*' | while read -r dir
 do
-    printf "\n## dir: ${dir}\n" >> "$outfile"
+    printf "\n### dir: ${dir}\n" >> "$outfile"
     # print autodocs for any go code
-    outContent=$(go doc -all "$dir" 2>/dev/null) && printf "### public Go code:\n\`\`\` ${outContent} \n\`\`\`\n" >> "${outfile}"
+    outContent=$(go doc -all "$dir" 2>/dev/null) && printf "\n*public Go code:*\n\`\`\` ${outContent} \n\`\`\`\n" >> "${outfile}"
     # link any readmes
     cat "${dir}/README.md" &>/dev/null && printf "See [README](${dir}/README.md) for more details.\n" >> "${outfile}"
 


### PR DESCRIPTION
### What

commit e33eabd84508b78925ca712b225258fa876c1b5c (HEAD -> feature/updated-docs)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Wed Dec 1 14:22:44 2021 +0000

    get-readme-scaffold.sh makes readme scaffold from go doc output

    shell script to crawl project looking for public go code. which is
    then documented with `go doc` and appended to readme-scaffold.md
    as preformatted text. Any README.md files found in package
    directories will be linked to in readme-scaffold.md.

    This change needed to make it easier to document this project.

### How to review

run `./get-readme-scaffold.sh` and see if you like the output in `readme-scaffold.md`

### Who can review

anyone
