### PR TITLE
add geotype query parameter, update query for updated schema

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -25,9 +25,10 @@ type HelloResponse struct {
 
 // GetDevHelloDatasetParams defines parameters for GetDevHelloDataset.
 type GetDevHelloDatasetParams struct {
-	Rows *[]string `json:"rows,omitempty"`
-	Cols *[]string `json:"cols,omitempty"`
-	Bbox *string   `json:"bbox,omitempty"`
+	Rows    *[]string `json:"rows,omitempty"`
+	Cols    *[]string `json:"cols,omitempty"`
+	Bbox    *string   `json:"bbox,omitempty"`
+	Geotype *string   `json:"geotype,omitempty"`
 }
 
 // ServerInterface represents all server handlers.
@@ -96,6 +97,17 @@ func (siw *ServerInterfaceWrapper) GetDevHelloDataset(w http.ResponseWriter, r *
 	err = runtime.BindQueryParameter("form", true, false, "bbox", r.URL.Query(), &params.Bbox)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Invalid format for parameter bbox: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "geotype" -------------
+	if paramValue := r.URL.Query().Get("geotype"); paramValue != "" {
+
+	}
+
+	err = runtime.BindQueryParameter("form", true, false, "geotype", r.URL.Query(), &params.Geotype)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid format for parameter geotype: %s", err), http.StatusBadRequest)
 		return
 	}
 

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -16,6 +16,7 @@ func main() {
 
 	dataset := flag.String("dataset", "", "name of dataset to query")
 	bbox := flag.String("bbox", "", "bounding box lat1,lon1,lat2,lon2")
+	geotype := flag.String("geotype", "", "geography type (LSOA or LAD)")
 	flag.Var(&rows, "rows", "row or row range")
 	flag.Var(&cols, "cols", "column name(s) to return")
 	maxmetrics := flag.Int("maxmetrics", 0, "max skinny rows to accept (default 0 means no limit)")
@@ -25,6 +26,7 @@ func main() {
 		usage()
 	}
 	fmt.Printf("bbox: %s\n", *bbox)
+	fmt.Printf("geotype: %s\n", *geotype)
 	fmt.Printf("rows:\n")
 	for _, r := range rows {
 		fmt.Printf("\t%s\n", r)
@@ -57,7 +59,7 @@ func main() {
 	}
 
 	ctx := context.Background()
-	body, err := app.Query(ctx, *dataset, *bbox, rows, cols)
+	body, err := app.Query(ctx, *dataset, *bbox, *geotype, rows, cols)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -66,6 +68,6 @@ func main() {
 }
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "usage: %s --dataset <dataset> [--rows rowspec[,...]] [--cols col[,...]] [--maxmetrics n]\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "usage: %s --dataset <dataset> [--rows rowspec[,...]|--bbox p1lat,p1lon,p2lat,pl2lon] [--geotype LSOA|LAD] [--cols col[,...]] [--maxmetrics n]\n", os.Args[0])
 	os.Exit(2)
 }

--- a/functions/hello/main.go
+++ b/functions/hello/main.go
@@ -115,11 +115,12 @@ func (app *App) Handler(ctx context.Context, req *events.APIGatewayProxyRequest)
 		return clientResponse("missing dataset path parameter"), nil
 	}
 	bbox := req.QueryStringParameters["bbox"]
+	geotype := req.QueryStringParameters["geotype"]
 	// empty list means ALL
 	rows := req.MultiValueQueryStringParameters["rows"]
 	cols := req.MultiValueQueryStringParameters["cols"]
 
-	body, err := app.d.Query(ctx, dataset, bbox, rows, cols)
+	body, err := app.d.Query(ctx, dataset, bbox, geotype, rows, cols)
 	if err != nil {
 		return errorResponse(http.StatusInternalServerError, "problem with query", err), nil
 	}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -41,6 +41,7 @@ func (svr *Server) GetDevHelloDataset(w http.ResponseWriter, r *http.Request, da
 	var rows []string
 	var cols []string
 	var bbox string
+	var geotype string
 	if dataset == "" {
 		sendError(w, http.StatusBadRequest, "dataset missing")
 		return
@@ -54,9 +55,12 @@ func (svr *Server) GetDevHelloDataset(w http.ResponseWriter, r *http.Request, da
 	if params.Bbox != nil {
 		bbox = *params.Bbox
 	}
+	if params.Geotype != nil {
+		geotype = *params.Geotype
+	}
 
 	ctx := r.Context()
-	csv, err := svr.queryDemo.Query(ctx, dataset, bbox, rows, cols)
+	csv, err := svr.queryDemo.Query(ctx, dataset, bbox, geotype, rows, cols)
 	if err != nil {
 		status := http.StatusInternalServerError
 		if errors.Is(err, demo.ErrTooManyMetrics) {

--- a/pkg/demo/errors.go
+++ b/pkg/demo/errors.go
@@ -3,7 +3,7 @@ package demo
 type Sentinel string
 
 const (
-	ErrMissingParams  = Sentinel("rows or cols is missing")
+	ErrMissingParams  = Sentinel("missing parameter")
 	ErrTooManyMetrics = Sentinel("too many metrics")
 	ErrInvalidTable   = Sentinel("invalid table")
 )

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -82,6 +82,10 @@ paths:
           name: bbox
           schema:
             type: string
+        - in: query
+          name: geotype
+          schema:
+            type: string
       responses:
         200:
           content:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -180,7 +180,7 @@ resource "aws_lambda_function" "fi-hello" {
 
   environment {
     variables = {
-      PGHOST          = "fi-database-1.cbhpmcuqy9vo.eu-central-1.rds.amazonaws.com"
+      PGHOST          = "fi-database-2.cbhpmcuqy9vo.eu-central-1.rds.amazonaws.com"
       PGPORT          = "54322"
       PGUSER          = "insights"
       PGDATABASE      = "census"


### PR DESCRIPTION
### What

bounding box queries now require a geotype query parameter which must match geo_type.name.

Updated bbox query to use new schema where geometry and coordinates are in geo table.


