### PR TITLE
change radius query to use centroid instead of boundary

### DIFF
--- a/pkg/geodata/geodata.go
+++ b/pkg/geodata/geodata.go
@@ -185,13 +185,14 @@ FROM
     data_ver,
     nomis_category
 WHERE ST_DWithin(
-    geo.wkb_geometry::geography,
+    geo.wkb_long_lat_geom::geography,
     ST_SetSRID(
         ST_Point(%f, %f),
         4326
     )::geography,
     %d
 )
+AND geo.valid
 AND geo_type.id = geo.type_id
 AND geo_type.name = %s
 AND geo_metric.geo_id = geo.id


### PR DESCRIPTION
### What

Now that the geo table has the centroid coordinates in a geometry field, change the radius query to use that field (wkb_long_lat_geom) instead of the boundary field (wkb_geometry).
