### PR TITLE
add extra as flag to inttests, add local + nonlocal urls

### DIFF
--- a/inttests/Makefile
+++ b/inttests/Makefile
@@ -13,16 +13,31 @@ update:
 test:
 	@go test ./... -tags=integration
 
+# Usual test (local)
+.PHONY: test
+test-local:
+	@go test ./... -tags=integration -local
+
 # Verbose test
 .PHONY: testv
 testv:
 	 @go test -v ./... -tags=integration
 
+# Verbose test (local)
+.PHONY: testv
+testv-local:
+	 @go test -v ./... -tags=integration -local
+
+
 # Very verbose test - displays long coloured diffs for failures
 .PHONY: testvv
 testvv:
-	 @go test -v ./... -tags=integration -args extra
+	 @go test -v ./... -tags=integration -extra
 
+# Very verbose test - displays long coloured diffs for failures (local)
+.PHONY: testvv
+testvv-local:
+	 @go test -v ./... -tags=integration -extra -local
 
 # Benchmark
 .PHONY: bench

--- a/inttests/main.go
+++ b/inttests/main.go
@@ -14,81 +14,118 @@ import (
 )
 
 type APITest = struct {
-	desc string
-	url  string
+	desc         string
+	baseURL      string
+	baseURLLocal string
+	query        string
 }
+
+const baseURL = `https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny`
+const baseURLLocal = `http://localhost:25252/dev/hello/skinny`
 
 var Tests = []APITest{
 	// all rows single col
 	{
 		"all rows single col",
-		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?cols=QS802EW0009`,
+		baseURL,
+		baseURLLocal,
+		`cols=QS802EW0009`,
 	},
 	// all cols single row
 	{
 		"all cols single row",
-		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?rows=E01002111`,
+		baseURL,
+		baseURLLocal,
+		`rows=E01002111`,
 	},
 	// single row + col
 	{
 		"rows param single cols param single",
-		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?rows=E01000001&cols=QS119EW0001`,
+		baseURL,
+		baseURLLocal,
+		`rows=E01000001&cols=QS119EW0001`,
 	},
 	// multi rows
 	{
 		"rows param multi single cols param single",
-		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?rows=E01000001&rows=E01000222&rows=E01000333&cols=QS117EW0001`,
+		baseURL,
+		baseURLLocal,
+		`rows=E01000001&rows=E01000222&rows=E01000333&cols=QS117EW0001`,
 	},
 	{
 		"rows param multi array cols param single",
-		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?rows=E01000100,E01000110,E01000200&cols=QS119EW0003`,
+		baseURL,
+		baseURLLocal,
+		`rows=E01000100,E01000110,E01000200&cols=QS119EW0003`,
 	},
 	{
 		"rows param multi range cols param single",
-		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?rows=E01001111...E01001211&cols=QS118EW0011`,
+		baseURL,
+		baseURLLocal,
+		`rows=E01001111...E01001211&cols=QS118EW0011`,
 	},
 	{
 		"rows param multi mixed cols param single",
-		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?rows=E01000001&rows=E01000100,E01000110,E01000200&rows=E01001111...E01001211&cols=QS118EW0011`,
+		baseURL,
+		baseURLLocal,
+		`rows=E01000001&rows=E01000100,E01000110,E01000200&rows=E01001111...E01001211&cols=QS118EW0011`,
 	},
 	// multi cols
 	{
 		"rows param single cols param multi single",
-		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?rows=E01000001&cols=QS119EW0001&cols=QS118EW0001&cols=QS117EW0001`,
+		baseURL,
+		baseURLLocal,
+		`rows=E01000001&cols=QS119EW0001&cols=QS118EW0001&cols=QS117EW0001`,
 	},
 	{
 		"rows param single cols param multi array",
-		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?rows=E01000001&cols=QS119EW0001,QS119EW0002,QS119EW0003`,
+		baseURL,
+		baseURLLocal,
+		`rows=E01000001&cols=QS119EW0001,QS119EW0002,QS119EW0003`,
 	},
 	{
 		"rows param single cols param multi range",
-		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?rows=E01000001&cols=QS118EW0001...QS118EW0011`,
+		baseURL,
+		baseURLLocal,
+		`rows=E01000001&cols=QS118EW0001...QS118EW0011`,
 	},
 	{
 		"rows param single cols param multi mixed",
-		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?rows=E01000001&cols=QS117EW0001&cols=QS119EW0001,QS119EW0002,QS119EW0003&cols=QS118EW0001...QS118EW0011`,
+		baseURL,
+		baseURLLocal,
+		`rows=E01000001&cols=QS117EW0001&cols=QS119EW0001,QS119EW0002,QS119EW0003&cols=QS118EW0001...QS118EW0011`,
 	},
 	// multi rows + cols
 	{
 		"rows param multi single cols param multi single",
-		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?rows=E01000001&rows=E01000222&rows=E01000333&cols=QS119EW0001&cols=QS118EW0001&cols=QS117EW0001`,
+		baseURL,
+		baseURLLocal,
+		`rows=E01000001&rows=E01000222&rows=E01000333&cols=QS119EW0001&cols=QS118EW0001&cols=QS117EW0001`,
 	},
 	{
 		"rows param multi array cols param multi array",
-		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?rows=E01000100,E01000110,E01000200&cols=QS119EW0001,QS119EW0002,QS119EW0003`,
+		baseURL,
+		baseURLLocal,
+		`rows=E01000100,E01000110,E01000200&cols=QS119EW0001,QS119EW0002,QS119EW0003`,
 	},
 	{
 		"rows param multi range cols param multi range",
-		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?rows=E01001111...E01001211&cols=QS118EW0001...QS118EW0011`,
+		baseURL,
+		baseURLLocal,
+		`rows=E01001111...E01001211&cols=QS118EW0001...QS118EW0011`,
 	},
 	{
 		"rows param multi mixed cols param multi mixed",
-		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?rows=E01000001&rows=E01000100,E01000110,E01000200&rows=E01001111...E01001211&cols=QS117EW0001&cols=QS119EW0001,QS119EW0002,QS119EW0003&cols=QS118EW0001...QS118EW0011`,
+		baseURL,
+		baseURLLocal,
+		`rows=E01000001&rows=E01000100,E01000110,E01000200&rows=E01001111...E01001211&cols=QS117EW0001&cols=QS119EW0001,QS119EW0002,QS119EW0003&cols=QS118EW0001...QS118EW0011`,
 	},
 	// bbox
 	{
 		"bbox param cols param multi mixed",
-		`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?bbox=0.1338,51.4635,0.1017,51.4647&cols=QS117EW0001&cols=QS119EW0001,QS119EW0002,QS119EW0003&cols=QS118EW0001...QS118EW0011&geotype=LSOA`,
+		baseURL,
+		baseURLLocal,
+		`bbox=0.1338,51.4635,0.1017,51.4647&cols=QS117EW0001&cols=QS119EW0001,QS119EW0002,QS119EW0003&cols=QS118EW0001...QS118EW0011&geotype=LSOA`,
 		//`https://5laefo1cxd.execute-api.eu-central-1.amazonaws.com/dev/hello/skinny?bbox=51.4635,0.1338,51.4647,0.1017&cols=QS117EW0001&cols=QS119EW0001,QS119EW0002,QS119EW0003&cols=QS118EW0001...QS118EW0011&geotype=LSOA`,
 	},
 }
@@ -96,16 +133,17 @@ var Tests = []APITest{
 var DataPref = "resp/"
 
 func main() {
-	// populate saved copies to allow test diffs
+	// populate saved copies to allow test diffs - NB this will always run against the non-local server
 	for _, test := range Tests {
-		b, _, err := HTTPget(test.url)
+		url := fmt.Sprintf(`%s?%s`, test.baseURL, test.query)
+		b, _, err := HTTPget(url)
 
 		if err != nil {
 			log.Print(err)
 		}
 
 		h := sha1Hash(b)
-		fmt.Printf("url: %s resp hash: %s\n", test.url, h)
+		fmt.Printf("url: %s resp hash: %s\n", url, h)
 
 		fn := DataPref + RespFilePrefix(test.desc) + h
 		f, err := os.Create(fn)


### PR DESCRIPTION
### What

Change 'extra' (more verbose) test option from cl arg to
flag. This change needed to allow multiple test options to
be passed in different combinations.

Add non-local and local base URLs to test case definitions.
Add 'local' flag to control tests being run against remote
or locally-running API.
These changes needed to allow tests to run locally.

### How to review

pull code, run make test, run make test-local

### Who can review

Anyone

NB - the CORS headers are missing from locally-running code! (OOS here but needs fixing)