### PR TITLE
add CORS '*' header to responses on data endpoint from api.go

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -64,6 +64,9 @@ func (siw *ServerInterfaceWrapper) GetDevHelloDataset(w http.ResponseWriter, r *
 
 	var err error
 
+	// add CORS header
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
 	// ------------- Path parameter "dataset" -------------
 	var dataset string
 


### PR DESCRIPTION
Add 'Access-Control-Allow-Origin: *' to responses from
/dev/hello/{dataset} endpoint from the server in api.go.
This change needed to allow web apps to consume this
endpoint.

### How to review

pull code
build and run API server locally with 'make debug'
run inttests against locally running server by cd-ing to inttests/ and running 'make test-local', verify CORS tests pass.

### Who can review

Anyone