### PR TITLE
make api return 204 if there are no results

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -112,7 +112,9 @@ func (svr *Server) GetDevHelloDataset(w http.ResponseWriter, r *http.Request, da
 	csv, err := svr.querygeodata.Query(ctx, dataset, bbox, location, radius, polygon, geotype, rows, cols)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if errors.Is(err, geodata.ErrTooManyMetrics) {
+		if errors.Is(err, geodata.ErrNoContent) {
+			status = http.StatusNoContent
+		} else if errors.Is(err, geodata.ErrTooManyMetrics) {
 			status = http.StatusForbidden
 		} else if errors.Is(err, geodata.ErrMissingParams) || errors.Is(err, geodata.ErrInvalidTable) {
 			status = http.StatusBadRequest

--- a/pkg/geodata/errors.go
+++ b/pkg/geodata/errors.go
@@ -6,6 +6,7 @@ const (
 	ErrMissingParams  = Sentinel("missing parameter")
 	ErrTooManyMetrics = Sentinel("too many metrics")
 	ErrInvalidTable   = Sentinel("invalid table")
+	ErrNoContent      = Sentinel("no data found")
 )
 
 func (e Sentinel) Error() string {

--- a/pkg/geodata/geodata.go
+++ b/pkg/geodata/geodata.go
@@ -387,6 +387,10 @@ func (app *Geodata) collectCells(ctx context.Context, sql string, include []stri
 		return "", err
 	}
 
+	if nmetrics == 0 {
+		return "", ErrNoContent
+	}
+
 	tgen := timer.New("generate")
 	tgen.Start()
 	err = tbl.Generate(&body, include)


### PR DESCRIPTION
### What

API results are cryptic and misleading when there are no results. Sometimes a single line of "geography_code" is printed, which isn't helpful.

This change makes the API return 204 and an empty body when there are no results.

HTTP/1.1 204 No Content
Access-Control-Allow-Origin: *
Date: Fri, 17 Dec 2021 15:12:29 GMT