### PR TITLE
fix inttests MatchingRespFile matching filenames with same prefix

### DIFF
--- a/inttests/main.go
+++ b/inttests/main.go
@@ -337,7 +337,8 @@ func MatchingRespFile(testDesc string) (fns []string, err error) {
 	targetFnPrefix := RespFilePrefix(testDesc)
 	for _, file := range filesInDataPref {
 		fn := file.Name()
-		if strings.HasPrefix(fn, targetFnPrefix) {
+		fnPrefix := fn[:len(fn)-40]
+		if fnPrefix == targetFnPrefix {
 			fns = append(fns, fn)
 		}
 	}


### PR DESCRIPTION
Fix issue where inttests/main.go MatchRespFile would mistake these
two for the same response file, because they have the same prefix:
census-tables-all-cols-single-row-6b9ff4934cdfbb586a3aa0a38c46d1f2cd3cc411
census-tables-all-cols-single-row-no-geography-393b71feac9169e275fe2a282dd2416eaaac4eb5

Fixed by comparing all except last 40 chars (sha1 length) of filenames
rather than using strings.HasPrefix.

### What

Describe what you have changed and why.

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
