### PR TITLE
default DSN, SetupDBOnceOnly db setup function, both for comptests

### DIFF
--- a/comptests/docker.go
+++ b/comptests/docker.go
@@ -11,6 +11,8 @@ import (
 	"gorm.io/gorm"
 )
 
+const DefaultDSN = "postgres://insights:insights@localhost:54322/censustest"
+
 func SetupDockerDB(dsn string) {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 

--- a/comptests/tests/main_test.go
+++ b/comptests/tests/main_test.go
@@ -26,13 +26,18 @@ Also see a real test  pkg/geodata/rowquery_test.go which uses
 
 */
 
-const dsn = "postgres://insights:insights@localhost:54322/censustest"
+/*
+you can use your own postgres dsn for tests, but it might clash with that in use by other tests.
+Safest is to use the default set in comptests/docker.DefaultDSN
+(which at time of writing was postgres://insights:insights@localhost:54322/censustest)
+*/
+const dsn = comptests.DefaultDSN
 
 var db *gorm.DB
 
 func init() {
 	comptests.SetupDockerDB(dsn)
-	model.SetupDB(dsn)
+	model.SetupDBOnceOnly(dsn)
 	var err error
 	db, err = gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if err != nil {

--- a/model/provision.go
+++ b/model/provision.go
@@ -49,6 +49,30 @@ func SetupDB(dsn string) {
 
 }
 
+// special case for use in comptests - only setup db if it has not already been set up. This is safe to call multiple times against the same db.
+func SetupDBOnceOnly(dsn string) {
+	// assume if censustest db exists, the work is done
+	_, pw, host, port, _ := ParseDSN(dsn)
+
+	{
+		db, err := gorm.Open(postgres.Open(CreatDSN("postgres", pw, host, port, "postgres")), &gorm.Config{})
+		if err != nil {
+			log.Print(err)
+		}
+
+		// check if db exists already, return if so
+		var isDBCreated bool
+		db.Raw("SELECT EXISTS (SELECT datname FROM pg_catalog.pg_database WHERE datname='censustest')").Scan(&isDBCreated)
+		if isDBCreated {
+			log.Println("Database already setup, skipping...")
+			return
+		}
+	}
+
+	// else run SetupDB
+	SetupDB(dsn)
+}
+
 // setup schema
 func Migrate(db *gorm.DB) {
 

--- a/pkg/geodata/rowquery_test.go
+++ b/pkg/geodata/rowquery_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ONSdigital/dp-find-insights-poc-api/pkg/database"
 )
 
-const dsn = "postgres://insights:insights@localhost:54323/censustest"
+const dsn = comptests.DefaultDSN
 
 // passing -args -kill=true to the test will kill docker postgres
 var kill = flag.Bool("kill", false, "docker kill postgres")
@@ -21,7 +21,7 @@ var kill = flag.Bool("kill", false, "docker kill postgres")
 // TODO Check empty
 func TestRowQuery(t *testing.T) {
 	comptests.SetupDockerDB(dsn)
-	model.SetupDB(dsn)
+	model.SetupDBOnceOnly(dsn)
 
 	db, err := database.Open("pgx", dsn)
 	if err != nil {


### PR DESCRIPTION
- Add DefaultDSN constant to comptests/docker.go. This can be
imported into component tests, and avoids tests thinking they
can set different dsn's for the test db in each test run (actually
only the first one to be used is valid)
- Add SetupDBOnceOnly function to model/provision.go. This is a
wrapper for SetupDB that is safe to call multiple times (checks
for existence of db and only calls SetupDB if not present). This
function can be called multiple times by different comptests
in the same test session.

These changes needed to allow multiple component tests to
run in the same test session.

### What

Describe what you have changed and why.

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
