### PR TITLE
don't repeat data bug reported by Patrick

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -44,10 +44,9 @@ func (md *Metadata) Get() (b []byte, err error) {
 
 	var mdr api.MetadataResponse
 
-	var newTabs api.Tables
-
 	for _, topic := range topics {
 
+		var newTabs api.Tables
 		var nd model.NomisDesc
 
 		for _, nd = range topic.NomisDescs {


### PR DESCRIPTION
data was wrongly repeated after the first QS structure due to incorrect scope of variable.

This fixes that problem.
