### PR TITLE
make cache size and ttl configurable through environment

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,8 @@ type Config struct {
 	WriteTimeout               time.Duration `envconfig:"WRITE_TIMEOUT"`
 	APIToken                   string        `envconfig:"API_TOKEN"`
 	EnableHeaderAuth           bool          `envconfig:"ENABLE_HEADER_AUTH"`
+	CacheSize                  int           `envconfig:"CACHE_SIZE"`
+	CacheTTL                   time.Duration `envconfig:"CACHE_TTL"`
 }
 
 var cfg *Config
@@ -37,6 +39,8 @@ func Get() (*Config, error) {
 		WriteTimeout:               30 * time.Second, // http WriteTimeout
 		APIToken:                   "",
 		EnableHeaderAuth:           false,
+		CacheSize:                  200,            // memory cache size in MB
+		CacheTTL:                   12 * time.Hour, // cache entry TTL
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,6 +29,8 @@ func TestConfig(t *testing.T) {
 					EnableDatabase:             false,
 					MaxMetrics:                 200000,
 					WriteTimeout:               30 * time.Second,
+					CacheSize:                  200,
+					CacheTTL:                   12 * time.Hour,
 				})
 			})
 

--- a/service/service.go
+++ b/service/service.go
@@ -92,7 +92,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 		}
 	}
 
-	cm, err := cache.New(5*time.Minute, 100) // example settings for now
+	cm, err := cache.New(cfg.CacheTTL, cfg.CacheSize)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What

Added CACHE_SIZE and CACHE_TTL environment variables.
Defaults 200 (MB) and 12 hours.

This will allow us to work around the issue where large responses (like metadata) are too big for bigcache shards.