### PR TITLE
don't return error on cache Set error; send response anyway

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -96,9 +96,11 @@ func (svr *Server) GetMetadataYear(w http.ResponseWriter, r *http.Request, year 
 			return
 		}
 
+		// if there is a problem saving response in cache, log it, but still send to client
 		err = ser.Set(ctx, body)
 		if err != nil {
-			return
+			log.Printf("could not cache %d bytes of metadata response: %v\n", len(body), err)
+			err = nil
 		}
 	}()
 


### PR DESCRIPTION
### What

I had the metadata endpoint returning an error to the client whenever the content could not be cached. This is dumb. Changed it to log an error, but send the response anyway.