### PR TITLE
add support for no-cache on metadata endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 
 require (
 	github.com/allegro/bigcache/v3 v3.0.1
-	github.com/davecgh/go-spew v1.1.1
 	github.com/eko/gocache/v2 v2.2.0
 	github.com/jszwec/csvutil v1.6.0
 	github.com/twpayne/go-geom v1.4.1
@@ -48,6 +47,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cucumber/gherkin-go/v19 v19.0.3 // indirect
 	github.com/cucumber/messages-go/v16 v16.0.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect

--- a/handlers/cache_control.go
+++ b/handlers/cache_control.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/ONSdigital/dp-find-insights-poc-api/cache"
+)
+
+type generateFunc func() ([]byte, error)
+
+// respond returns cached data if it is available, or generates and caches new data.
+func (svr *Server) respond(w http.ResponseWriter, r *http.Request, generate generateFunc) {
+
+	// add CORS header
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	var err error
+	var body []byte
+
+	key := cache.CacheKey(r)
+
+	// allocate a serialiser for this cache key
+	ser := svr.cm.AllocateEntry(key)
+	defer ser.Free()
+
+	func() {
+		ctx := context.Background()
+
+		// lock cache key before doing any cache operations
+		ser.Lock()
+		defer ser.Unlock()
+
+		if !noCache(r) {
+			body, err = ser.Get(ctx)
+			if err == nil {
+				return
+			}
+		}
+
+		body, err = generate()
+		if err != nil {
+			return
+		}
+
+		// if there is a problem saving response in cache, log it, but still send to client
+		err = ser.Set(ctx, body)
+		if err != nil {
+			log.Printf("could not cache: %q (%d bytes): %v\n", key, len(body), err)
+			err = nil
+		}
+	}()
+
+	if err != nil {
+		sendError(w, http.StatusInternalServerError, err.Error())
+	} else {
+		w.Write(body)
+	}
+}
+
+// noCache is true if a Cache-Control header contains "no-cache"
+// (This is just enough to let us get around caching during development.
+// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
+func noCache(req *http.Request) bool {
+	for _, value := range req.Header.Values("Cache-Control") {
+		for _, token := range strings.Split(value, ",") {
+			if strings.EqualFold(token, "no-cache") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/handlers/cache_control_test.go
+++ b/handlers/cache_control_test.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"net/http"
+	"testing"
+)
+
+func Test_noCache(t *testing.T) {
+	var tests = map[string]struct {
+		headers []string
+		want    bool
+	}{
+		"no Cache-Control header": {
+			nil,
+			false,
+		},
+		"single Cache-Control header w/o no-cache": {
+			[]string{"no-store"},
+			false,
+		},
+		"single Cache-Control header with no-cache": {
+			[]string{"no-cache"},
+			true,
+		},
+		"multiple Cache-Control headers w/o no-cache": {
+			[]string{
+				"no-store",
+				"max-age=0",
+			},
+			false,
+		},
+		"multiple Cache-Control headers with no-cache": {
+			[]string{
+				"no-cache",
+				"max-age=0",
+				"must-revalidate",
+			},
+			true,
+		},
+	}
+
+	for name, test := range tests {
+		req := &http.Request{}
+		req.Header = map[string][]string{
+			"Cache-Control": test.headers,
+		}
+		got := noCache(req)
+		if got != test.want {
+			t.Errorf("%s: %t, want %t", name, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
### What

Support for avoiding the cache on metadata endpoint:

curl -H "Cache-control: no-cache" http://localhost:25252/metadata/2011

Also extracted cache get/set logic into a generic function that can be used for other handlers later.