### PR TITLE
have limit message show the current limit

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -150,6 +150,7 @@ func (svr *Server) GetQueryYear(w http.ResponseWriter, r *http.Request, year int
 }
 
 func sendError(w http.ResponseWriter, code int, message string) {
+	log.Printf("request error: %s", message)
 	e := api.Error{
 		Error: message,
 	}

--- a/pkg/geodata/geodata.go
+++ b/pkg/geodata/geodata.go
@@ -73,7 +73,7 @@ func (app *Geodata) collectCells(ctx context.Context, sql string, include []stri
 		nmetrics++
 		if app.maxMetrics > 0 {
 			if nmetrics > app.maxMetrics {
-				return "", ErrTooManyMetrics
+				return "", fmt.Errorf("%w: limit is %d", ErrTooManyMetrics, app.maxMetrics)
 			}
 		}
 


### PR DESCRIPTION
### What

When a query hits the too-many-metric error, print the current limit in the error message.