### PR TITLE
enable caching for query endpoint; fix some bugs

### DIFF
--- a/features/steps/example_component.go
+++ b/features/steps/example_component.go
@@ -3,7 +3,6 @@ package steps
 import (
 	"context"
 	"net/http"
-	"time"
 
 	"github.com/ONSdigital/dp-find-insights-poc-api/config"
 	"github.com/ONSdigital/dp-find-insights-poc-api/service"
@@ -83,9 +82,8 @@ func (c *Component) DoGetHealthcheckOk(cfg *config.Config, buildTime string, git
 	}, nil
 }
 
-func (c *Component) DoGetHTTPServer(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer {
+func (c *Component) DoGetHTTPServer(bindAddr string, router http.Handler) service.HTTPServer {
 	c.HTTPServer.Addr = bindAddr
 	c.HTTPServer.Handler = router
-	c.HTTPServer.WriteTimeout = writeTimeout
 	return c.HTTPServer
 }

--- a/handlers/ckmeans.go
+++ b/handlers/ckmeans.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ONSdigital/dp-find-insights-poc-api/api"
 	"github.com/ONSdigital/dp-find-insights-poc-api/config"
+	"github.com/ONSdigital/dp-find-insights-poc-api/pkg/geodata"
 )
 
 func (svr *Server) GetCkmeansYear(w http.ResponseWriter, r *http.Request, year int, params api.GetCkmeansYearParams) {
@@ -43,7 +44,7 @@ func (svr *Server) GetCkmeansYear(w http.ResponseWriter, r *http.Request, year i
 			k = *params.K
 		}
 		if cat == "" || geotype == "" || k == 0 {
-			return nil, fmt.Errorf("%w: cat, geotype and k required", ErrBadRequest)
+			return nil, fmt.Errorf("%w: cat, geotype and k required", geodata.ErrMissingParams)
 		}
 
 		ctx := r.Context()
@@ -95,7 +96,7 @@ func (svr *Server) GetCkmeansratioYear(w http.ResponseWriter, r *http.Request, y
 			k = *params.K
 		}
 		if cat1 == "" || cat2 == "" || geotype == "" || k == 0 {
-			return nil, fmt.Errorf("%w: cat1, cat2, geotype and k required", ErrBadRequest)
+			return nil, fmt.Errorf("%w: cat1, cat2, geotype and k required", geodata.ErrMissingParams)
 		}
 
 		ctx := r.Context()

--- a/pkg/geodata/ckmeans.go
+++ b/pkg/geodata/ckmeans.go
@@ -211,7 +211,7 @@ AND data_ver.ver_string = '2.2'
 	var metrics []float64
 	for geoID, metricCat1 := range metricsCat1 {
 		metricCat2, prs := metricsCat2[geoID]
-		if prs == false {
+		if !prs {
 			return nil, ErrPartialContent
 		}
 		metrics = append(metrics, metricCat1/metricCat2)

--- a/pkg/geodata/errors.go
+++ b/pkg/geodata/errors.go
@@ -6,7 +6,6 @@ const (
 	ErrMissingParams  = Sentinel("missing parameter")
 	ErrInvalidParams  = Sentinel("invalid parameter")
 	ErrTooManyMetrics = Sentinel("too many metrics")
-	ErrInvalidTable   = Sentinel("invalid table")
 	ErrNoContent      = Sentinel("no data found")
 	ErrPartialContent = Sentinel("insufficient data found")
 )

--- a/pkg/geodata/geodata_test.go
+++ b/pkg/geodata/geodata_test.go
@@ -25,7 +25,7 @@ func TestGetCensusQuery(t *testing.T) {
 		{
 			desc:    "no arguments",
 			args:    geodata.CensusQuerySQLArgs{},
-			wantErr: errors.New("must specify a condition (rows, bbox, location/radius, and/or polygon)"),
+			wantErr: geodata.ErrMissingParams,
 		},
 		// Rows
 		{
@@ -103,17 +103,17 @@ AND nomis_category.year = data_ver.census_year
 		{
 			desc:    "bbox error - non-numeric data",
 			args:    geodata.CensusQuerySQLArgs{BBox: "X,51.3624781092781,0.17687729439413147,51.673778133460246"},
-			wantErr: errors.New("error parsing bbox \"X,51.3624781092781,0.17687729439413147,51.673778133460246\": strconv.ParseFloat: parsing \"X\": invalid syntax"),
+			wantErr: geodata.ErrInvalidParams,
 		},
 		{
 			desc:    "bbox error - too few coords",
 			args:    geodata.CensusQuerySQLArgs{BBox: "-0.370947083400182,51.3624781092781"},
-			wantErr: errors.New("valid bbox is 'lon,lat,lon,lat', received \"-0.370947083400182,51.3624781092781\": invalid parameter"),
+			wantErr: geodata.ErrInvalidParams,
 		},
 		{
 			desc:    "bbox error - too many coords",
 			args:    geodata.CensusQuerySQLArgs{BBox: "-0.370947083400182,51.3624781092781,0.17687729439413147,51.673778133460246,-0.370947083400182,0.17687729439413147,51.673778133460246"},
-			wantErr: errors.New("valid bbox is 'lon,lat,lon,lat', received \"-0.370947083400182,51.3624781092781,0.17687729439413147,51.673778133460246,-0.370947083400182,0.17687729439413147,51.673778133460246\": invalid parameter"),
+			wantErr: geodata.ErrInvalidParams,
 		},
 		// Columns
 		{
@@ -380,7 +380,7 @@ AND (
 		{
 			desc:    "all rows, too many tokens",
 			args:    geodata.CensusQuerySQLArgs{Geos: []string{"x", "all"}},
-			wantErr: errors.New("if used, ALL must be first and only rows= token"),
+			wantErr: geodata.ErrInvalidParams,
 		},
 		{
 			desc: "all rows, all categories",
@@ -426,7 +426,7 @@ AND nomis_category.year = data_ver.census_year
 			t.Errorf("%s: got these geography column values - '%s', wanted '%s'", test.desc, gotInclude, test.wantInclude)
 		}
 		if test.wantErr != nil {
-			if !reflect.DeepEqual(gotErr.Error(), test.wantErr.Error()) {
+			if !errors.Is(gotErr, test.wantErr) {
 				t.Errorf("%s: got this error = '%s', wanted '%s'", test.desc, gotErr, test.wantErr)
 			}
 		} else if gotErr != nil {

--- a/pkg/geodata/polygon.go
+++ b/pkg/geodata/polygon.go
@@ -1,7 +1,6 @@
 package geodata
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -19,18 +18,18 @@ func (c *Point) String() string {
 func ParsePolygon(s string) ([]Point, error) {
 	a := strings.Split(s, ",")
 	if len(a)%2 != 0 {
-		return nil, errors.New("polygon must have even number of coordinates")
+		return nil, fmt.Errorf("%w: polygon must have even number of coordinates", ErrInvalidParams)
 	}
 
 	var points []Point
 	for i := 0; i < len(a); i += 2 {
 		lon, err := strconv.ParseFloat(a[i], 64)
 		if err != nil {
-			return nil, fmt.Errorf("%s: %w", a[i], err)
+			return nil, fmt.Errorf("%w: %s: %s", ErrInvalidParams, a[i], err)
 		}
 		lat, err := strconv.ParseFloat(a[i+1], 64)
 		if err != nil {
-			return nil, fmt.Errorf("%s: %w", a[i+1], err)
+			return nil, fmt.Errorf("%w: %s: %s", ErrInvalidParams, a[i+1], err)
 		}
 
 		p := Point{
@@ -41,10 +40,10 @@ func ParsePolygon(s string) ([]Point, error) {
 	}
 
 	if len(points) < 4 {
-		return nil, errors.New("must be at least 4 points in polygon")
+		return nil, fmt.Errorf("%w: must be at least 4 points in polygon", ErrInvalidParams)
 	}
 	if points[len(points)-1] != points[0] {
-		return nil, errors.New("first and last point must match")
+		return nil, fmt.Errorf("%w: first and last point must match", ErrInvalidParams)
 	}
 
 	return points, nil

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/ONSdigital/dp-find-insights-poc-api/config"
 	"github.com/ONSdigital/dp-find-insights-poc-api/pkg/aws"
@@ -30,8 +29,8 @@ func NewServiceList(initialiser Initialiser) *ExternalServiceList {
 type Init struct{}
 
 // GetHTTPServer creates an http server
-func (e *ExternalServiceList) GetHTTPServer(bindAddr string, router http.Handler, writeTimeout time.Duration) HTTPServer {
-	s := e.Init.DoGetHTTPServer(bindAddr, router, writeTimeout)
+func (e *ExternalServiceList) GetHTTPServer(bindAddr string, router http.Handler) HTTPServer {
+	s := e.Init.DoGetHTTPServer(bindAddr, router)
 	return s
 }
 
@@ -54,10 +53,13 @@ func (e *ExternalServiceList) GetHealthCheck(cfg *config.Config, buildTime, gitC
 }
 
 // DoGetHTTPServer creates an HTTP Server with the provided bind address and router
-func (e *Init) DoGetHTTPServer(bindAddr string, router http.Handler, writeTimeout time.Duration) HTTPServer {
+func (e *Init) DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer {
 	s := dphttp.NewServer(bindAddr, router)
 	s.HandleOSSignals = false
-	s.Server.WriteTimeout = writeTimeout
+	// dhttp.NewServer sets up the server with default timeouts, but we are using the TimeoutHandler,
+	// so reset these values to avoid interference.
+	s.Server.WriteTimeout = 0
+	s.Server.ReadTimeout = 0
 	return s
 }
 

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"net/http"
-	"time"
 
 	"github.com/ONSdigital/dp-find-insights-poc-api/config"
 	"github.com/ONSdigital/dp-find-insights-poc-api/pkg/aws"
@@ -17,7 +16,7 @@ import (
 
 // Initialiser defines the methods to initialise external services
 type Initialiser interface {
-	DoGetHTTPServer(bindAddr string, router http.Handler, writeTimeout time.Duration) HTTPServer
+	DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer
 	DoGetHealthCheck(cfg *config.Config, buildTime, gitCommit, version string) (HealthChecker, error)
 	DoGetAWS() (*aws.Clients, error)
 	DoGetDatabase(driverName, dsn string) (*database.Database, error)

--- a/service/mock/initialiser.go
+++ b/service/mock/initialiser.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ONSdigital/dp-find-insights-poc-api/service"
 	"net/http"
 	"sync"
-	"time"
 )
 
 // Ensure, that InitialiserMock does implement service.Initialiser.
@@ -29,7 +28,7 @@ var _ service.Initialiser = &InitialiserMock{}
 // 			DoGetDatabaseFunc: func(driverName string, dsn string) (*database.Database, error) {
 // 				panic("mock out the DoGetDatabase method")
 // 			},
-// 			DoGetHTTPServerFunc: func(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer {
+// 			DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer {
 // 				panic("mock out the DoGetHTTPServer method")
 // 			},
 // 			DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
@@ -49,7 +48,7 @@ type InitialiserMock struct {
 	DoGetDatabaseFunc func(driverName string, dsn string) (*database.Database, error)
 
 	// DoGetHTTPServerFunc mocks the DoGetHTTPServer method.
-	DoGetHTTPServerFunc func(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer
+	DoGetHTTPServerFunc func(bindAddr string, router http.Handler) service.HTTPServer
 
 	// DoGetHealthCheckFunc mocks the DoGetHealthCheck method.
 	DoGetHealthCheckFunc func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error)
@@ -72,8 +71,6 @@ type InitialiserMock struct {
 			BindAddr string
 			// Router is the router argument value.
 			Router http.Handler
-			// WriteTimeout is the writeTimeout argument value.
-			WriteTimeout time.Duration
 		}
 		// DoGetHealthCheck holds details about calls to the DoGetHealthCheck method.
 		DoGetHealthCheck []struct {
@@ -155,37 +152,33 @@ func (mock *InitialiserMock) DoGetDatabaseCalls() []struct {
 }
 
 // DoGetHTTPServer calls DoGetHTTPServerFunc.
-func (mock *InitialiserMock) DoGetHTTPServer(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer {
+func (mock *InitialiserMock) DoGetHTTPServer(bindAddr string, router http.Handler) service.HTTPServer {
 	if mock.DoGetHTTPServerFunc == nil {
 		panic("InitialiserMock.DoGetHTTPServerFunc: method is nil but Initialiser.DoGetHTTPServer was just called")
 	}
 	callInfo := struct {
-		BindAddr     string
-		Router       http.Handler
-		WriteTimeout time.Duration
+		BindAddr string
+		Router   http.Handler
 	}{
-		BindAddr:     bindAddr,
-		Router:       router,
-		WriteTimeout: writeTimeout,
+		BindAddr: bindAddr,
+		Router:   router,
 	}
 	mock.lockDoGetHTTPServer.Lock()
 	mock.calls.DoGetHTTPServer = append(mock.calls.DoGetHTTPServer, callInfo)
 	mock.lockDoGetHTTPServer.Unlock()
-	return mock.DoGetHTTPServerFunc(bindAddr, router, writeTimeout)
+	return mock.DoGetHTTPServerFunc(bindAddr, router)
 }
 
 // DoGetHTTPServerCalls gets all the calls that were made to DoGetHTTPServer.
 // Check the length with:
 //     len(mockedInitialiser.DoGetHTTPServerCalls())
 func (mock *InitialiserMock) DoGetHTTPServerCalls() []struct {
-	BindAddr     string
-	Router       http.Handler
-	WriteTimeout time.Duration
+	BindAddr string
+	Router   http.Handler
 } {
 	var calls []struct {
-		BindAddr     string
-		Router       http.Handler
-		WriteTimeout time.Duration
+		BindAddr string
+		Router   http.Handler
 	}
 	mock.lockDoGetHTTPServer.RLock()
 	calls = mock.calls.DoGetHTTPServer

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -35,7 +35,7 @@ var funcDoGetHealthcheckErr = func(cfg *config.Config, buildTime string, gitComm
 	return nil, errHealthcheck
 }
 
-var funcDoGetHTTPServerNil = func(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer {
+var funcDoGetHTTPServerNil = func(bindAddr string, router http.Handler) service.HTTPServer {
 	return nil
 }
 
@@ -70,11 +70,11 @@ func TestRun(t *testing.T) {
 			return hcMock, nil
 		}
 
-		funcDoGetHTTPServer := func(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer {
+		funcDoGetHTTPServer := func(bindAddr string, router http.Handler) service.HTTPServer {
 			return serverMock
 		}
 
-		funcDoGetFailingHTTPSerer := func(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer {
+		funcDoGetFailingHTTPSerer := func(bindAddr string, router http.Handler) service.HTTPServer {
 			return failingServerMock
 		}
 
@@ -220,7 +220,7 @@ func TestClose(t *testing.T) {
 		Convey("Closing the service results in all the dependencies being closed in the expected order", func() {
 
 			initMock := &serviceMock.InitialiserMock{
-				DoGetHTTPServerFunc: func(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer {
+				DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer {
 					return serverMock
 				},
 				DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
@@ -249,7 +249,7 @@ func TestClose(t *testing.T) {
 			}
 
 			initMock := &serviceMock.InitialiserMock{
-				DoGetHTTPServerFunc: func(bindAddr string, router http.Handler, writeTimeout time.Duration) service.HTTPServer {
+				DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer {
 					return failingserverMock
 				},
 				DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {


### PR DESCRIPTION
### What

* enable caching for query endpoint
* fix timeouts to return 503 instead of just dropping the connection
* fix problem with detecting multiple "ALL" tokens in rows= query parameter
* more consistent error to http status code mapping