### PR TITLE
Add default $POSTGRES_PASSWORD to setup for comptests

### DIFF
--- a/comptests/docker.go
+++ b/comptests/docker.go
@@ -13,6 +13,7 @@ import (
 )
 
 const DefaultDSN = "postgres://insights:insights@localhost:54322/censustest"
+const DefaultPostgresPW = "mylocalsecret"
 
 func SetupDockerDB(dsn string) {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
@@ -20,7 +21,17 @@ func SetupDockerDB(dsn string) {
 	_, _, host, port, _ := model.ParseDSN(dsn)
 	user := "postgres"
 	db := "postgres"
-	pw := os.Getenv("POSTGRES_PASSWORD")
+
+	// get password from env, or fall back to default
+	var pw string
+	envPW := os.Getenv("POSTGRES_PASSWORD")
+	if envPW != "" {
+		pw = envPW
+	} else {
+		pw = DefaultPostgresPW
+		os.Setenv("POSTGRES_PASSWORD", DefaultPostgresPW)
+	}
+
 	dsn = model.CreatDSN(user, pw, host, port, db)
 
 	// is docker postgres+postgis running?


### PR DESCRIPTION
### What

Extend comptests/docker.go to use a default value for the
$POSTGRES_PASSWORD env var if it is not set (in this case,
the default value will be used on the go code AND set as an
env var for docker to pickup).

This change needed to allow comptests to run without setting
up the env first.

### How to review

```
unset POSTGRES_PASSWORD
docker kill postgis
make test-comptest 
```
Comptests should start up a new postgis in docker and run ok, even without a POSTGRES_PASSWORD value in the env 
### Who can review

Describe who worked on the changes, so that other people can review.
