### PR TITLE
blank geo response if no geometry available (e.g. E&W)

### DIFF
--- a/pkg/geodata/geo.go
+++ b/pkg/geodata/geo.go
@@ -63,6 +63,11 @@ func (app *Geodata) Geo(ctx context.Context, year int, geocode string, geoname s
 		return nil, err
 	}
 
+	// return no data if there is no geometry (this is the case for England and Wales, Regions, and other geotypes)
+	if centroid == nil || boundary == nil || bbox == nil {
+		return nil, sentinel.ErrNoContent
+	}
+
 	geomCentroid, err := wkb.Unmarshal(centroid)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What

commit c58b518c244d939080f4e8a6935f73769c202fef (HEAD -> fix/catch-no-geometry-issues-for-geo-endpoint-requests, origin/fix/catch-no-geometry-issues-for-geo-endpoint-requests)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Wed Mar 23 15:15:12 2022 +0000

    blank geo response if no geometry available (e.g. E&W)

    Return no data from geo endpoint if there is no geometry available
    in the geo table for the requested geography (but there is a name
    and a code). This covers cases like England and Wales, which
    are geographies we hold data for but have no associated geometry.

    This change needed to avoid error response when trying to marshal
    blank geometry values to geoJSON.


### How to review

read the code etc, pull it, run locally and try this:
curl http://localhost:25252/geo/2011\?geocode\=K04000001
(should get blank response, vs doing:
curl https://cep5lmkia0.execute-api.eu-west-1.amazonaws.com/dev/geo/2011\?geocode\=K04000001
(will get {"error":"EOF"})

### Who can review

Anyone